### PR TITLE
Make a Go executable depends on a thirdparty library

### DIFF
--- a/src/redis/CMakeLists.txt
+++ b/src/redis/CMakeLists.txt
@@ -1,4 +1,6 @@
 ExternalGoProject_Add(go_redis github.com/hoisie/redis)
+ExternalGoProject_Add(go_spew github.com/davecgh/go-spew)
 
 add_go_executable(redis_lister    # executable name
-                  go_redis)       # everything else is a dependency
+  go_redis
+  go_spew)       # everything else is a dependency

--- a/src/redis/redis_lister.go
+++ b/src/redis/redis_lister.go
@@ -1,7 +1,12 @@
 package main
 
-import "github.com/hoisie/redis"
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hoisie/redis"
+)
+
 import "log"
 
 func main() {
@@ -14,4 +19,5 @@ func main() {
 	for _, k := range keys {
 		fmt.Printf("key: %s\n", k)
 	}
+	spew.Dump(keys)
 }


### PR DESCRIPTION
I tried to add a third party dependency to `src/redis`, but it seems that `add_go_executable` doesn't handle dependencies, and I got the following errors:

```
-- Build files have been written to: /tmp/cmake_cxx_go/build
Scanning dependencies of target assert
Scanning dependencies of target go_redis
Scanning dependencies of target go_spew
Scanning dependencies of target adder
[ 20%] Generating /.timestamp
package github.com/davecgh/go-spew: no buildable Go source files in /tmp/cmake_cxx_go/build/go/src/github.com/davecgh/go-spew
make[2]: *** [src/redis/CMakeFiles/go_spew] Error 1
make[1]: *** [src/redis/CMakeFiles/go_spew.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 20%] Built target adder
[ 20%] Built target go_redis
[ 20%] Built target assert
make: *** [all] Error 2
```